### PR TITLE
Update node version 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ outputs:
   action-result:
     description: 'Result of operation to add apis to apiconnect discovery repo'  
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
To remove the warning in the action workflow 
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ibm-apiconnect/apic-discovery-action@main. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```